### PR TITLE
[CLEANUP] Fix new RuboCop warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       parser (>= 2.3.1.2, < 2.5)
       rainbow (~> 2.0)
     require_all (1.4.0)
-    rubocop (0.47.1)
+    rubocop (0.48.0)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)

--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,7 @@ Rails.application.load_tasks
 Rake::Task['test'].clear
 task default: :ci
 
-task ci: [
-  :rubocop, :reek, :rails_best_practices, :haml_lint, :bundle_audit
-]
+task ci: %i(rubocop reek rails_best_practices haml_lint bundle_audit)
 
 task :rubocop do
   sh 'rubocop --rails app/ db/seeds.rb Gemfile Rakefile'

--- a/app/controllers/admin/dogs_controller.rb
+++ b/app/controllers/admin/dogs_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   # dogs CRUD
   class DogsController < ApplicationController
-    before_action :set_dog, only: [:edit, :update, :destroy]
+    before_action :set_dog, only: %i(edit update destroy)
 
     # GET /admin/dogs
     def index

--- a/app/controllers/admin/espressos_controller.rb
+++ b/app/controllers/admin/espressos_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   # espresso CRUD
   class EspressosController < ApplicationController
-    before_action :set_espresso, only: [:edit, :update, :destroy]
+    before_action :set_espresso, only: %i(edit update destroy)
 
     # GET /admin/espressos
     def index

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -2,7 +2,7 @@
 
 # books CRUD
 class BooksController < ApplicationController
-  before_action :set_book, only: [:edit, :update, :destroy]
+  before_action :set_book, only: %i(edit update destroy)
 
   # GET /books
   def index

--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -2,7 +2,7 @@
 
 # cats CRUD
 class CatsController < ApplicationController
-  before_action :set_cat, only: [:edit, :update, :destroy]
+  before_action :set_cat, only: %i(edit update destroy)
 
   # GET /cats
   def index


### PR DESCRIPTION
- use the new Ruby 2.0 syntax for arrays of symbols
- update RuboCop