### PR TITLE
[CLEANUP] Explicitly set the Linux dist on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os: linux
 
+dist: bionic
+
 language: ruby
 
 cache:


### PR DESCRIPTION
This fixes a notice in the `.travis.yml`.