### PR TITLE
[BUGFIX] Stop precompiling the assets during the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,5 @@ before_script:
 
 script:
   - RAILS_ENV=test bundle exec rake --trace ci
-  - RAILS_ENV=test bundle exec rails assets:precompile
   - gem install brakeman
   - brakeman -z -6


### PR DESCRIPTION
We do not need this, and this curently breaks the build.