### PR TITLE
[BUGFIX] Use a maintained action for installing Ruby for the CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Set up Ruby"
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.0
       - name: "Check the environment"
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Set up Ruby"
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.0
       - name: "Install dependencies"


### PR DESCRIPTION
`ruby/setup-ruby` is the better action to use for installing Ruby
in GitHub Actions (particularly for more recent Ruby versions);
`actions/setup-ruby` is not.