### PR TITLE
[TASK] Update to bundler-audit 0.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,5 @@ group :test do
   gem 'rubocop-rake', require: false
 
   # Security checker
-  gem 'bundler-audit', '~>0.7.0.1', require: false
+  gem 'bundler-audit', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,9 +70,9 @@ GEM
     bootsnap (1.7.4)
       msgpack (~> 1.0)
     builder (3.2.4)
-    bundler-audit (0.7.0.1)
+    bundler-audit (0.8.0)
       bundler (>= 1.2.0, < 3)
-      thor (>= 0.18, < 2)
+      thor (~> 1.0)
     code_analyzer (0.5.2)
       sexp_processor
     coderay (1.1.3)
@@ -265,7 +265,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  bundler-audit (~> 0.7.0.1)
+  bundler-audit
   haml
   haml-rails
   haml_lint

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -4,13 +4,13 @@ namespace :bundler_audit do
   desc 'Update bundler-audit database'
   task update: :environment do
     require 'bundler/audit/cli'
-    Bundler::Audit::CLI.new.update
+    Bundler::Audit::CLI.start(['update'])
   end
 
   desc 'Check gems for vulnerabilities using bundler-audit'
   task check: :environment do
     require 'bundler/audit/cli'
-    Bundler::Audit::CLI.new.check
+    Bundler::Audit::CLI.start(['check'])
   end
 
   desc 'Update vulnerabilities database and check gems using bundler-audit'


### PR DESCRIPTION
This update has revealed a bug in out bundler-audit-related Rake
tasks (i.e., we were calling the tasks incorrectly). This is now
fixed.