### PR TITLE
[FEATURE] Always build the containers with `dip provision`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ is "default" and that docker-compose uses "docker-compose exec":
 | `dip bundle …`             | run `bundler`                                |
 | `dip compose …`            | run a docker-compose command                 |
 | `dip compose build`        | (re)build the containers                     |
-| `dip compose build --no-cache` | rebuild the containers after a version update (yarn, node, bundler, …) |
 | `dip compose ps`           | list the running containers                  |
 | `dip down`                 | shut down all containers                     |
 | `dip rails c`              | run the rails console                        |

--- a/dip.yml
+++ b/dip.yml
@@ -60,6 +60,7 @@ interaction:
 
 provision:
   - dip compose down --volumes
+  - dip compose build
   - dip bundle install
   - dip yarn install
   - dip rails db:setup


### PR DESCRIPTION
This ensure that the containers are up to date after a configuration
change, e.g., a bundler update.

Also drop the reference to building without cache from the README
as we have been handling this by increasing the version number of
the image for some time now.