### PR TITLE
[BUGFIX] Fix local warning about the number of Puma workers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ x-backend: &backend
     <<: *env
     BOOTSNAP_CACHE_DIR: /usr/local/bundle/_bootsnap
     WEBPACKER_DEV_SERVER_HOST: webpacker
-    WEB_CONCURRENCY: 1
+    WEB_CONCURRENCY: 0
     HISTFILE: /app/log/.bash_history
     EDITOR: vi
 


### PR DESCRIPTION
The local development environment should not use Puma in
clustered mode.