### PR TITLE
[BUGFIX] Remove automatic milestones from the Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # Milestone "0 Closed Beta"
-    milestone: 3
 
   - package-ecosystem: "bundler"
     directory: "/"
@@ -15,8 +13,6 @@ updates:
       interval: "daily"
     label:
       - "dependencies"
-    # Milestone "0 Closed Beta"
-    milestone: 3
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -24,6 +20,3 @@ updates:
       interval: "daily"
     label:
       - "dependencies"
-    # Milestone "0 Closed Beta"
-    milestone: 3
-    versioning-strategy: "increase"


### PR DESCRIPTION
This project has no milestones, and hence we cannot set them for PRs.