### PR TITLE
[TASK] Use the automatic labels for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "dependencies"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "dependencies"


### PR DESCRIPTION
The automatic labels work just fine, and using them helps simplify
our Dependabot configuration.