### PR TITLE
[TASK] Blacklist some Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "rails"
+      - dependency-name: "psych"
+        versions: [ "4.x" ]
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@rails/ujs"
+      - dependency-name: "@rails/webpacker"
+      - dependency-name: "webpacker"
+    versioning-strategy: "increase"


### PR DESCRIPTION
- We want to update/upgrade `rails` manually.
- We want to keep the versions of `rails` and `@rails/ujs` in sync.
- We want to keep our current versions of `webpack` and `webpacker`
  as we're currently working on getting rid of both.