### PR TITLE
[TASK] Disable Dependabot updates of indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,35 +6,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "[TASK]"
 
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      # allow both direct and indirect updates for all packages
-      - dependency-type: "all"
     ignore:
       - dependency-name: "rails"
       - dependency-name: "psych"
         versions: [ "4.x" ]
     versioning-strategy: "increase"
-    commit-message:
-      prefix: "[TASK]"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      # allow both direct and indirect updates for all packages
-      - dependency-type: "all"
     ignore:
       - dependency-name: "@rails/ujs"
       - dependency-name: "@rails/webpacker"
       - dependency-name: "webpacker"
     versioning-strategy: "increase"
-    commit-message:
-      prefix: "[TASK]"


### PR DESCRIPTION
These result in too many PRs. We'll update the indirect dependencies
manually every once in a while.

Also drop the prefixes for the commit messages as Dependabot uses a colon,
which would result in commit messages like this:
"[TASK]: Bump foo from 1.0.0 to 1.0.1"