### PR TITLE
[TASK] Upgrade to Node.js 16.15.1

### DIFF
--- a/.dockerdev/compose.yml
+++ b/.dockerdev/compose.yml
@@ -9,7 +9,7 @@ x-app: &app
       YARN_VERSION: '1.22.18'
   # We need to update the version number of the image each time
   # we update any of the variables above.
-  image: crud-base:2.0.2
+  image: crud-base:2.0.3
   environment: &env
     NODE_ENV: ${NODE_ENV:-development}
     RAILS_ENV: ${RAILS_ENV:-development}


### PR DESCRIPTION
As we only state the Node major version in the dependency, a new Docker
image version is sufficient to pull in the upgrade now that Node 16.15.x
is available as a Debian package.