### PR TITLE
[TASK] Upgrade to psych 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "rails"
-      - dependency-name: "psych"
-        versions: [ "4.x" ]
     versioning-strategy: "increase"
 
   - package-ecosystem: "npm"

--- a/Gemfile
+++ b/Gemfile
@@ -46,10 +46,8 @@ end
 group :test do
   # Style checkers
   gem 'haml_lint', require: false
+  gem 'psych'
   gem 'rails_best_practices', require: false
-  # Psych 4 currently breaks with YAML aliases, probably in the DB
-  # configuration. This might also be a bug in webpacker.
-  gem 'psych', '<4'
   gem 'reek', require: false
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,8 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    psych (3.3.2)
+    psych (4.0.4)
+      stringio
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -232,6 +233,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
+    stringio (3.0.2)
     sysexits (1.2.0)
     temple (0.8.2)
     thor (1.2.1)
@@ -263,7 +265,7 @@ DEPENDENCIES
   jsbundling-rails
   listen
   net-smtp
-  psych (< 4)
+  psych
   puma
   rack-mini-profiler
   rails (= 6.1.6.1)


### PR DESCRIPTION
Now that Webpacker and Webpack are gone, upgrading the psych gem will
not create any problems anymore.