### PR TITLE
[TASK] Explicitly require Sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source 'https://rubygems.org'
 # Rails
 gem 'rails', '6.1.6.1'
 
+# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
+gem 'sprockets-rails'
+
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rake
+  sprockets-rails
   sqlite3
   turbolinks (~> 5)
 


### PR DESCRIPTION
Rails 7 does not depend on Sprockets by default anymore. As we are still using Sprockets, we need to make this dependency explicit in preparation for the upgrade to Rails 7.