### PR TITLE
Revert "[TASK] Update to Bundler 2.3.23 (#424)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,4 +267,4 @@ DEPENDENCIES
   turbolinks (~> 5)
 
 BUNDLED WITH
-   2.3.23
+   2.3.22


### PR DESCRIPTION
This Bundler update broke installation of the sqlite gem.

This reverts commit 42e972f93a18e5ad2341de6d3ae760572741dbc1.