### PR TITLE
[CLEANUP] Remove workaround for bug in older version of the mail gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,6 @@ gem 'turbolinks', '~> 5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
-# Temporarily needed for some other gem.
-gem 'net-smtp'
-
 group :development do
   # Provide better error pages
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,6 @@ DEPENDENCIES
   haml_lint
   jsbundling-rails
   listen
-  net-smtp
   psych
   puma
   rack-mini-profiler


### PR DESCRIPTION
Since the upgrade to Rails 7, the `net-*` gems are not needed anymore.