### PR TITLE
[FEATURE] Add testing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,12 @@ group :development do
 end
 
 group :test do
+  # Use system testing
+  # [https://guides.rubyonrails.org/testing.html#system-testing]
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
+
   # Style checkers
   gem 'haml_lint', require: false
   gem 'psych'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -79,6 +81,15 @@ GEM
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    capybara (3.38.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     code_analyzer (0.5.5)
       sexp_processor
     coderay (1.1.3)
@@ -126,6 +137,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -153,6 +165,7 @@ GEM
       ast (~> 2.4.1)
     psych (5.1.0)
       stringio
+    public_suffix (5.0.1)
     puma (6.1.0)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -229,6 +242,11 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.8.1)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sexp_processor (4.16.1)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
@@ -253,9 +271,16 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -268,6 +293,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bundler-audit
+  capybara
   cssbundling-rails
   haml
   haml-rails
@@ -284,9 +310,11 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rake
+  selenium-webdriver
   sprockets-rails
   sqlite3
   turbolinks (~> 5)
+  webdrivers
 
 BUNDLED WITH
    2.4.7


### PR DESCRIPTION
This brings our `Gemfile` more in line with the Rails 7 defaults (even though we are not using those gems at the moment yet).